### PR TITLE
A few improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.json]
+indent_style = tab

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
 	// See http://go.microsoft.com/fwlink/?LinkId=827846
 	// for the documentation about the extensions.json format
 	"recommendations": [
-		"dbaeumer.vscode-eslint"
+		"dbaeumer.vscode-eslint",
+		"esbenp.prettier-vscode"
 	]
 }

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
 		"typescript": "^5.2.2"
 	},
 	"dependencies": {
-		"langchain": "^0.0.169"
+		"langchain": "^0.0.169",
+		"ollama": "^0.3.0"
 	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import * as vscode from "vscode";
 import { Ollama } from "langchain/llms/ollama";
 import { PromptTemplate } from "langchain/prompts";
 import setup from "./setup";
+import { logger } from "./logger";
 
 const cfg = vscode.workspace.getConfiguration();
 const model = cfg.get(
@@ -17,9 +18,9 @@ const temperature = cfg.get(
 const topP = cfg.get("chjweb.local-ai-code-completion.model.top_p", 0.3);
 
 const ollama = new Ollama({
-    model,
-    temperature,
-    topP,
+  model,
+  temperature,
+  topP,
 });
 
 const promptTemplate = PromptTemplate.fromTemplate(
@@ -128,7 +129,7 @@ export async function activate(context: vscode.ExtensionContext) {
           );
 
           const now = performance.now();
-          console.log("Total time:", (now - start) / 1000, "seconds");
+          logger.debug("Total time:", (now - start) / 1000, "seconds");
         }
 
         vscode.window
@@ -229,4 +230,6 @@ function findLine(text: string, endLine: number, startLine: number): string {
 }
 
 // This method is called when your extension is deactivated
-export function deactivate() {}
+export function deactivate() {
+  logger.dispose();
+}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,5 @@
+import { window } from "vscode";
+
+export const logger = window.createOutputChannel("Local AI Completion", {
+  log: true,
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,23 @@
 {
 	"compilerOptions": {
-		"module": "commonjs",
-		"target": "ES2020",
+		"module": "Node16",
+		"moduleResolution": "Node16",
+		"target": "ES6",
 		"outDir": "out",
 		"lib": [
-			"ES2020",
+			"ES6",
 			"DOM"
 		],
 		"sourceMap": true,
+		"esModuleInterop": true,
 		"rootDir": "src",
-		"strict": true   /* enable all strict type-checking options */
+		"strict": true, /* enable all strict type-checking options */
 		/* Additional Checks */
-		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
+		"noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
 		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
 		// "noUnusedParameters": true,  /* Report errors on unused parameters. */
+		"useDefineForClassFields": true,
+		"useUnknownInCatchVariables": true,
+		"allowSyntheticDefaultImports": true
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1054,6 +1054,11 @@ object-hash@^3.0.0:
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-3.0.0.tgz#73f97f753e7baffc0e2cc9d6e079079744ac82e9"
   integrity sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==
 
+ollama@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/ollama/-/ollama-0.3.0.tgz#278aecba32e890b732cd017f85ac10d703c9d7a3"
+  integrity sha512-+eaNmtirwiAcfLW84RUZA2rhEwl7pOtLJ39zTVkBWRbRQ1Q1JubTf1k/wmxvICs1APVA+iYgYeYif0n5GUflhw==
+
 once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"


### PR DESCRIPTION
First, sorry for the messy PR. I know it has way too many changes in various places.

I was using it and improving to my use case

What it does:
- Adds a logger that outputs to an output pane in VSCode (not as console.* that only logs when debbuging)
- Uses Ollama API instead of spawning a command
- Adds a config for generation timeout
- Adds a config for the base url of the Ollama API (so you can use it with a local server)
- Properly handles the ESM modules that were being loaded with require
- Fixes a bug that when aborting a prompt it would not work
- Handles a clean exit, disposing resources and shutting down the server if it was initiated by vscode
- Improves model downloading (no need to specify tags for the models, `latest` will be the default) and the progress is reported correctly